### PR TITLE
REDCORE-446 [tests] modify default value for releasing extension

### DIFF
--- a/build/gulp-config.json.dist
+++ b/build/gulp-config.json.dist
@@ -1,6 +1,6 @@
 {
 	"wwwDir"        : "/var/www/html/yoursite",
-	"release_dir"   : "./tests/joomla-cms3/releases/",
+	"release_dir"   : "../tests/joomla-cms3/releases/",
 	"watchInterval" : "500",
 	"defaultTasks"  : ["copy", "watch", "copyRedcore", "watchRedcore", "browser-sync"],
 	"browserConfig" : {


### PR DESCRIPTION
since we are in /build/ directory, the right path for generating the extension package would be:

`"../tests/joomla-cms3/releases/"`
