### PR TITLE
REDCORE-446 [tests] use Gulp to generate the package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,17 @@ before_script:
 - sudo apt-get install fluxbox -y --force-yes
 - fluxbox &
 - sleep 3 # give fluxbox some time to start
-- cd tests
-- composer install --prefer-dist
 
 script:
+- cd tests
+- composer install --prefer-dist
 - php vendor/bin/robo check:robo-file-version
 - php ../build/.travis/phppec.php ../extensions/component/ ../extensions/libraries/ ../extensions/modules/ ../extensions/plugins/
 - php ../build/.travis/phpcs.php
 - php ../build/.travis/misseddebugcodechecker.php ../extensions/component/ ../extensions/libraries/ ../extensions/modules/ ../extensions/plugins/
 - mv acceptance.suite.dist.yml acceptance.suite.yml
 - mv api.suite.dist.yml api.suite.yml
+- npm install
 - vendor/bin/robo run:tests
 - if [ $TRAVIS_PHP_VERSION == 5.5 ]; then vendor/bin/robo send:codeception-output-to-slack C02L0SE5E xoxp-2309442657-4789197868-4789233706-68cec7; fi
 notifications:

--- a/tests/RoboFile.php
+++ b/tests/RoboFile.php
@@ -234,6 +234,8 @@ class RoboFile extends \Robo\Tasks
 			$this->getSelenium();
 		}
 
+		$this->prepareReleasePackages();
+
 		$this->getComposer();
 
 		$this->taskComposerInstall()->run();
@@ -241,8 +243,8 @@ class RoboFile extends \Robo\Tasks
 		$this->runSelenium($options['selenium_path']);
 
 		$this->taskWaitForSeleniumStandaloneServer()
-		     ->run()
-		     ->stopOnFail();
+			->run()
+			->stopOnFail();
 
 		// Make sure to Run the Build Command to Generate AcceptanceTester
 		$this->_exec("vendor/bin/codecept build");
@@ -353,5 +355,16 @@ class RoboFile extends \Robo\Tasks
 
 		// Running Selenium server
 		$this->_exec("java -jar $path >> selenium.log 2>&1 &");
+	}
+
+	/**
+	 * Prepares the .zip packages of the extension to be installed in Joomla
+	 */
+	public function prepareReleasePackages()
+	{
+		$this->taskGulpRun('release')
+			->arg('--skip-version')
+			->dir('../build')
+			->run();
 	}
 }

--- a/tests/acceptance.suite.dist.yml
+++ b/tests/acceptance.suite.dist.yml
@@ -37,5 +37,5 @@ modules:
             admin email: 'admin@mydomain.com'      # email Id of the Admin
             language: 'English (United Kingdom)'   # Language in which you want the Application to be Installed
         AcceptanceHelper:
-            repo_folder: '/home/travis/build/redCOMPONENT-COM/redCORE/extensions' # Path to the Extension to be installed via Install from folder
+            install packages url: 'http://localhost/tests/joomla-cms3/tests/joomla-cms3/releases/'     # the url that points to the extension .zip package defined in your gulp-config.json file at the /build/ folder
 error_level: "E_ALL & ~E_STRICT & ~E_DEPRECATED"

--- a/tests/acceptance/install/02-InstallExtensionCept.php
+++ b/tests/acceptance/install/02-InstallExtensionCept.php
@@ -11,5 +11,5 @@ $I = new \AcceptanceTester($scenario);
 
 $I->wantToTest('redCORE installation in Joomla 3');
 $I->doAdministratorLogin();
-$path = $I->getConfiguration('repo_folder');
-$I->installExtensionFromDirectory($path);
+$path = $I->getConfiguration('install packages url');
+$I->installExtensionFromUrl($path . 'redCORE.zip');


### PR DESCRIPTION
This changes modify the way Travis installs redCORE. Now uses Gulp to generate the package, and aftewards Joomla installs that generated package via "install from url"
